### PR TITLE
Fill gemspec metadata (source_code_uri, changelog_uri, etc)

### DIFF
--- a/activerecord-pretty-comparator.gemspec
+++ b/activerecord-pretty-comparator.gemspec
@@ -14,6 +14,10 @@ Gem::Specification.new do |spec|
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.0.0"
 
+  spec.metadata["homepage_uri"] = spec.homepage
+  spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "#{spec.homepage}/blob/main/CHANGELOG.md"
+
   gemspec = File.basename(__FILE__)
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|


### PR DESCRIPTION
## What
Thank you for great talk on Reject on Rails 2024!

I visited your gem page https://rubygems.org/gems/activerecord-pretty-comparator , but there is no direct URL of this repo.

So I fill this repo's url to metadata.

See also https://guides.rubygems.org/specification-reference/#metadata